### PR TITLE
修复make_underlying_symbol的PY3平台永远是RB的小bug

### DIFF
--- a/rqalpha_mod_ctp/ctp/utils.py
+++ b/rqalpha_mod_ctp/ctp/utils.py
@@ -69,7 +69,7 @@ def make_underlying_symbol(id_or_symbol):
     if six.PY2:
         return filter(lambda x: x not in '0123456789 ', id_or_symbol).upper()
     else:
-        return ''.join(list(filter(lambda x: x not in '0123456789 ', 'rb1705'))).upper()
+        return ''.join(list(filter(lambda x: x not in '0123456789 ', id_or_symbol))).upper()
 
 
 def make_order_book_id(symbol):


### PR DESCRIPTION
最近在工作中基于这个mod修改做一些东西， 希望可以参与到这个项目的完善中