### PR TITLE
fix import error when using pip 10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,11 @@
 # limitations under the License.
 
 from os.path import dirname, join
-from pip.req import parse_requirements
+try: # for pip >= 10
+    from pip._internal.req import parse_requirements
+except ImportError: # for pip <= 9.0.3
+    from pip.req import parse_requirements
+
 
 from setuptools import (
     find_packages,


### PR DESCRIPTION
they moved pip.req to pip._internal.req in pip 10, which caused an error when installing this mod.
this pull request fix this bug and can be installed successfully on my machine